### PR TITLE
docs:update docs about how to extends ctx.helper

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -283,7 +283,7 @@ class Application extends EggApplication {
     if (!this[HELPER]) {
       /**
        * The Helper class which can be used as utility function.
-       * Files from `${baseDir}/app/helper` will be loaded to the prototype of Helper,
+       * We support developers to extend Helper through ${baseDir}/app/extend/helper.js ,
        * then you can use all method on `ctx.helper` that is a instance of Helper.
        */
       class Helper extends this.BaseContextClass {}


### PR DESCRIPTION
How to extend helper
We support developers to extend Helper through app/extend/helper.js. But on the official website is /app/helper.
eggjs/egg#4361

<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->

<!--
- any feature?
- close https://github.com/eggjs/egg/ISSUE_URL
-->